### PR TITLE
Use `STANDARD` in buf config

### DIFF
--- a/testdata/buf.yaml
+++ b/testdata/buf.yaml
@@ -3,7 +3,7 @@ modules:
   - path: proto
 lint:
   use:
-    - DEFAULT
+    - STANDARD
 breaking:
   use:
     - FILE


### PR DESCRIPTION
> WARN	Category DEFAULT referenced in your buf.yaml is deprecated. It has been replaced by category STANDARD.
>
>	The concept of a default rule has been introduced. A default rule is a rule that will be run
>	if no rules are explicitly configured in your buf.yaml. Run buf config ls-lint-rules or
>	buf config ls-breaking-rules to see which rules are defaults. With this introduction, having a category
>	also named DEFAULT is confusing, as while it happpens that all the rules in the DEFAULT category
>	are also default rules, the name has become overloaded.
>
>	As with all buf changes, this change is backwards-compatible: DEFAULT will continue to work.
>	We recommend replacing DEFAULT in your buf.yaml, but no action is immediately necessary.