### PR TITLE
Fix `merge_method` for mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,7 +15,6 @@ pull_request_rules:
     actions:
       queue:
         name: default
-        merge_method: squash
   - name: Handle merged
     conditions:
       - 'label=wait-merge'
@@ -27,6 +26,7 @@ pull_request_rules:
         remove: ["wait-merge"]
 queue_rules:
   - name: default
+    merge_method: squash
     merge_conditions:
       - check-success=testdata
       - check-success=build


### PR DESCRIPTION
> The configuration uses the deprecated merge_method attribute of the queue action in one or more pull_request_rules. It > > must now be used under the queue_rules configuration.
> A brownout is planned on September 16th, 2024.
> This option will be removed on October 21st, 2024.
> For more information: https://docs.mergify.com/configuration/file-format/#queue-rules